### PR TITLE
Use 'checkout' instead of 'track' to follow upstream branches.

### DIFF
--- a/vcs-sync/svn-ocaml/sync.sh
+++ b/vcs-sync/svn-ocaml/sync.sh
@@ -12,7 +12,7 @@ for repo in $REPOS; do
   for branch in `git branch -r | grep '^  svn/' | grep -v '^  svn/tags'`;
   do
       name=`echo "$branch" | awk -F '/' '{print $2}'`
-      git branch -f --track "$name" "$branch" || exit $?
+      git checkout -B $name $branch || exit $?
   done
 
   for tag in `git branch -r | grep '^  svn/tags'`;


### PR DESCRIPTION
Tracking a branch created by git-svn [no longer works](http://git.661346.n2.nabble.com/git-svn-Use-prefix-by-default-td7594288.html#a7597159) as of git 1.8.3.2, since there's no valid upstream remote.
